### PR TITLE
Remove normalisation of values from 'exact' matcher

### DIFF
--- a/src/SmartGamma/Behat/PactExtension/Infrastructure/Interaction/BehatMatcher.php
+++ b/src/SmartGamma/Behat/PactExtension/Infrastructure/Interaction/BehatMatcher.php
@@ -24,7 +24,7 @@ class BehatMatcher implements MatcherInterface
      */
     public function like($value)
     {
-        return $this->pactMatcher->like($this->normolizeValue($value));
+        return $this->pactMatcher->like($this->normaliseValue($value));
     }
 
     /**
@@ -34,7 +34,7 @@ class BehatMatcher implements MatcherInterface
      */
     public function exact($value)
     {
-        return $this->normolizeValue($value);
+        return $value;
     }
 
     /**
@@ -96,7 +96,7 @@ class BehatMatcher implements MatcherInterface
      *
      * @return bool | float | int | null | string
      */
-    private function normolizeValue(string $string)
+    private function normaliseValue(string $string)
     {
         if (empty($string)) {
             return '';


### PR DESCRIPTION
It was converting a string into an integer unnecessarily. It should probably just use the type that's passed into the function and rely on the developer to cast appropriately.